### PR TITLE
fix: close file handles

### DIFF
--- a/src/root.ts
+++ b/src/root.ts
@@ -66,7 +66,7 @@ export class PdbRootStream {
         let fileHandle: FileHandle;
         let pdbRootStream: PdbRootStream;
         try {
-            const fileHandle = await open(filePath, 'r');
+            fileHandle = await open(filePath, 'r');
 
             const blockSizeReadOffset = pdbSignature.length;
             const blockSize = await readUInt32(fileHandle, blockSizeReadOffset);
@@ -125,7 +125,7 @@ export class PdbRootStream {
 
             pdbRootStream = new PdbRootStream(blockSize, directoryBytesLength, streamDirectory);
         } finally {
-            fileHandle!?.close();
+            await fileHandle!?.close();
         }
 
         return pdbRootStream;


### PR DESCRIPTION
### Description

Variable was not set due to const in try/catch so the handle was not getting closed.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
