### PR TITLE
feat!: make web-compatible

### DIFF
--- a/spec/pdb.spec.ts
+++ b/spec/pdb.spec.ts
@@ -1,21 +1,16 @@
+import { openAsBlob } from 'node:fs';
 import { PdbFile } from '../src/pdb';
 
 describe('pdbFile', () => {
-    it('should throw if file does not exist', async () => {
-        await expectAsync(PdbFile.createFromFile('./spec/support/does-not-exist.pdb')).toBeRejectedWithError('PDB file does not exist at path: ./spec/support/does-not-exist.pdb');
-    });
-
-    it('should throw if file does not have .pdb extension', async () => {
-        await expectAsync(PdbFile.createFromFile('./spec/support/bugsplat.dll')).toBeRejectedWithError('File does not have .pdb extension: ./spec/support/bugsplat.dll');
-    });
-
     it('should read guid of a .pdb file', async () => {
-        const pdbFile = await PdbFile.createFromFile('./spec/support/bugsplat.pdb');
+        const blob = await openAsBlob('./spec/support/bugsplat.pdb');
+        const pdbFile = await PdbFile.createFromBlob(blob);
         expect(pdbFile.guid).toMatch(/^E546B55B6D214E86871B40AC35CD0D461$/);
     });
 
     it('should read guid of an unreal .pdb file', async () => {
-        const pdbFile = await PdbFile.createFromFile('./spec/support/myunrealcrasher.pdb');
+        const blob = await openAsBlob('./spec/support/myunrealcrasher.pdb');
+        const pdbFile = await PdbFile.createFromBlob(blob);
         expect(pdbFile.guid).toMatch(/^C0BB5F2717804AD8A2CBEAD4C9CD7FDB1$/);
     });
 

--- a/spec/pe.spec.ts
+++ b/spec/pe.spec.ts
@@ -1,31 +1,28 @@
+import { openAsBlob } from 'node:fs';
 import { PeFile } from '../src/pe';
 
 describe('peFile', () => {
-    it('should throw if file does not exist', async () => {
-        await expectAsync(PeFile.createFromFile('./spec/support/does-not-exist.exe')).toBeRejectedWithError('PE file does not exist at path: ./spec/support/does-not-exist.exe');
-    });
-
-    it('should throw if file does not have .exe or .dll extension', async () => {
-        await expectAsync(PeFile.createFromFile('./spec/support/bugsplat.pdb')).toBeRejectedWithError('File does not have .exe or .dll extension: ./spec/support/bugsplat.pdb');
-    });
-
     it('should read guid of a .exe file', async () => {
-        const pdbFile = await PeFile.createFromFile('./spec/support/bssndrpt.exe');
+        const blob = await openAsBlob('./spec/support/bssndrpt.exe');
+        const pdbFile = await PeFile.createFromBlob(blob);
         expect(pdbFile.guid).toMatch(/^64FB82D565000$/);
     });
 
     it('should read guid of a .dll file', async () => {
-        const pdbFile = await PeFile.createFromFile('./spec/support/bugsplat.dll');
+        const blob = await openAsBlob('./spec/support/bugsplat.dll');
+        const pdbFile = await PeFile.createFromBlob(blob);
         expect(pdbFile.guid).toMatch(/^64FB82ED7A000$/);
     });
 
     it('should read guid of a .NET core .dll file', async () => {
-        const pdbFile = await PeFile.createFromFile('./spec/support/netcore.dll');
+        const blob = await openAsBlob('./spec/support/netcore.dll');
+        const pdbFile = await PeFile.createFromBlob(blob);
         expect(pdbFile.guid).toMatch(/^9271620112000$/);
     });
 
     it('should read guid of .pdb file with no timestamp section', async () => {
-        const pdbFile = await PeFile.createFromFile('./spec/support/unityengine.dll');
+        const blob = await openAsBlob('./spec/support/unityengine.dll');
+        const pdbFile = await PeFile.createFromBlob(blob);
         expect(pdbFile.guid).toMatch(/^0000000000000000000000000000000018000$/);
     });
 });

--- a/spec/root.spec.ts
+++ b/spec/root.spec.ts
@@ -1,9 +1,10 @@
+import { openAsBlob } from 'node:fs';
 import { PdbRootStream } from '../src/root';
-import { PdbFile } from '../src/pdb';
 
 describe('root', () => {
     it('should create instance of root stream', async () => {
-        const rootStream = await PdbRootStream.createFromFile('./spec/support/bugsplat.pdb');
+        const blob = await openAsBlob('./spec/support/bugsplat.pdb');
+        const rootStream = await PdbRootStream.createFromBlob(blob);
         expect(rootStream).not.toBeNull();
     });
 });

--- a/spec/signature.spec.ts
+++ b/spec/signature.spec.ts
@@ -16,6 +16,7 @@ describe('signature', () => {
 
             expect(success).toBeTrue();
             expect(error).toBeUndefined();
+            expect(fakeReader.releaseLock).toHaveBeenCalled();
         });
 
         it('should return error if wrong number of bytes read', async () => {
@@ -33,6 +34,7 @@ describe('signature', () => {
 
             expect(success).toBeFalse();
             expect(error?.message).toMatch(/wrong number of bytes read/);
+            expect(fakeReader.releaseLock).toHaveBeenCalled();
         });
 
         it('should return error if invalid signature', async () => {
@@ -50,9 +52,8 @@ describe('signature', () => {
 
             expect(success).toBeFalse();
             expect(error?.message).toMatch(/Invalid PDB signatures differ at 0/);
+            expect(fakeReader.releaseLock).toHaveBeenCalled();
         });
-
-        // TODO BG should release lock
     });
 
     describe('verifyPeSignature', () => {
@@ -70,6 +71,7 @@ describe('signature', () => {
 
             expect(success).toBeTrue();
             expect(error).toBeUndefined();
+            expect(fakeReader.releaseLock).toHaveBeenCalled();
         });
 
         it('should return error if wrong number of bytes read', async () => {
@@ -87,6 +89,7 @@ describe('signature', () => {
 
             expect(success).toBeFalse();
             expect(error?.message).toMatch(/wrong number of bytes read/);
+            expect(fakeReader.releaseLock).toHaveBeenCalled();
         });
 
         it('should return error if invalid signature', async () => {
@@ -104,6 +107,7 @@ describe('signature', () => {
 
             expect(success).toBeFalse();
             expect(error?.message).toMatch(/Invalid PE signatures differ at 0/);
+            expect(fakeReader.releaseLock).toHaveBeenCalled();
         });
     });
 });

--- a/spec/signature.spec.ts
+++ b/spec/signature.spec.ts
@@ -1,20 +1,18 @@
-import { FileHandle } from 'node:fs/promises';
 import { pdbSignature, peSignature, verifyPdbSignature, verifyPeSignature } from '../src/signature';
 
 describe('signature', () => {
     describe('verifyPdbSignature', () => {
         it('should verify pdb signature', async () => {
             const buffer = Buffer.from(pdbSignature);
-            const bytesRead = buffer.length;
-            const fileHandle: jasmine.SpyObj<FileHandle> = jasmine.createSpyObj('FileHandle', ['read']);
-            fileHandle.read.and.callFake(
-                async (readBuffer: Buffer, offset?: number, length?: number, position?: number) => {
-                    readBuffer.set(buffer, offset);
-                    return { bytesRead, buffer };
-                }
-            );
+            const fakeStream: jasmine.SpyObj<any> = jasmine.createSpyObj('ReadableStream', ['getReader']);
+            const fakeReader: jasmine.SpyObj<any> = jasmine.createSpyObj('ReadableStreamDefaultReader', ['read', 'releaseLock']);
+            const blob: jasmine.SpyObj<Blob> = jasmine.createSpyObj('Blob', ['slice', 'stream']);
+            blob.slice.and.returnValue(blob);
+            blob.stream.and.returnValue(fakeStream);
+            fakeStream.getReader.and.returnValue(fakeReader);
+            fakeReader.read.and.resolveTo({ done: false, value: buffer });
 
-            const { success, error } = await verifyPdbSignature(fileHandle as any);
+            const { success, error } = await verifyPdbSignature(blob);
 
             expect(success).toBeTrue();
             expect(error).toBeUndefined();
@@ -22,53 +20,53 @@ describe('signature', () => {
 
         it('should return error if wrong number of bytes read', async () => {
             const buffer = Buffer.from(pdbSignature);
-            const bytesRead = buffer.length - 1;
-            const fileHandle: jasmine.SpyObj<FileHandle> = jasmine.createSpyObj('FileHandle', ['read']);
-            fileHandle.read.and.callFake(
-                async (readBuffer: Buffer, offset?: number, length?: number, position?: number) => {
-                    readBuffer.set(buffer, offset);
-                    return { bytesRead, buffer };
-                }
-            );
+            const shorterBuffer = buffer.subarray(0, buffer.length - 1);
+            const fakeStream: jasmine.SpyObj<any> = jasmine.createSpyObj('ReadableStream', ['getReader']);
+            const fakeReader: jasmine.SpyObj<any> = jasmine.createSpyObj('ReadableStreamDefaultReader', ['read', 'releaseLock']);
+            const blob: jasmine.SpyObj<Blob> = jasmine.createSpyObj('Blob', ['slice', 'stream']);
+            blob.slice.and.returnValue(blob);
+            blob.stream.and.returnValue(fakeStream);
+            fakeStream.getReader.and.returnValue(fakeReader);
+            fakeReader.read.and.resolveTo({ done: false, value: shorterBuffer });
 
-            const { success, error } = await verifyPdbSignature(fileHandle as any);
+            const { success, error } = await verifyPdbSignature(blob);
 
             expect(success).toBeFalse();
             expect(error?.message).toMatch(/wrong number of bytes read/);
         });
 
         it('should return error if invalid signature', async () => {
-            const buffer = Buffer.from(pdbSignature);
-            const bytesRead = buffer.length;
-            const fileHandle: jasmine.SpyObj<FileHandle> = jasmine.createSpyObj('FileHandle', ['read']);
-            fileHandle.read.and.callFake(
-                async (readBuffer: Buffer, offset?: number, length?: number, position?: number) => {
-                    readBuffer.set(buffer, offset);
-                    readBuffer[0] = 0;
-                    return { bytesRead, buffer };
-                }
-            );
+            const badBuffer = Buffer.from(pdbSignature);
+            const fakeStream: jasmine.SpyObj<any> = jasmine.createSpyObj('ReadableStream', ['getReader']);
+            const fakeReader: jasmine.SpyObj<any> = jasmine.createSpyObj('ReadableStreamDefaultReader', ['read', 'releaseLock']);
+            const blob: jasmine.SpyObj<Blob> = jasmine.createSpyObj('Blob', ['slice', 'stream']);
+            badBuffer[0] = 0;
+            blob.slice.and.returnValue(blob);
+            blob.stream.and.returnValue(fakeStream);
+            fakeStream.getReader.and.returnValue(fakeReader);
+            fakeReader.read.and.resolveTo({ done: false, value: badBuffer });
 
-            const { success, error } = await verifyPdbSignature(fileHandle as any);
+            const { success, error } = await verifyPdbSignature(blob);
 
             expect(success).toBeFalse();
             expect(error?.message).toMatch(/Invalid PDB signatures differ at 0/);
         });
+
+        // TODO BG should release lock
     });
 
     describe('verifyPeSignature', () => {
         it('should verify pe signature', async () => {
             const buffer = Buffer.from(peSignature);
-            const bytesRead = buffer.length;
-            const fileHandle: jasmine.SpyObj<FileHandle> = jasmine.createSpyObj('FileHandle', ['read']);
-            fileHandle.read.and.callFake(
-                async (readBuffer: Buffer, offset?: number, length?: number, position?: number) => {
-                    readBuffer.set(buffer, offset);
-                    return { bytesRead, buffer };
-                }
-            );
+            const fakeStream: jasmine.SpyObj<any> = jasmine.createSpyObj('ReadableStream', ['getReader']);
+            const fakeReader: jasmine.SpyObj<any> = jasmine.createSpyObj('ReadableStreamDefaultReader', ['read', 'releaseLock']);
+            const blob: jasmine.SpyObj<Blob> = jasmine.createSpyObj('Blob', ['slice', 'stream']);
+            blob.slice.and.returnValue(blob);
+            blob.stream.and.returnValue(fakeStream);
+            fakeStream.getReader.and.returnValue(fakeReader);
+            fakeReader.read.and.resolveTo({ done: false, value: buffer });
 
-            const { success, error } = await verifyPeSignature(fileHandle as any, 0);
+            const { success, error } = await verifyPeSignature(blob, 0);
 
             expect(success).toBeTrue();
             expect(error).toBeUndefined();
@@ -76,34 +74,33 @@ describe('signature', () => {
 
         it('should return error if wrong number of bytes read', async () => {
             const buffer = Buffer.from(peSignature);
-            const bytesRead = buffer.length - 1;
-            const fileHandle: jasmine.SpyObj<FileHandle> = jasmine.createSpyObj('FileHandle', ['read']);
-            fileHandle.read.and.callFake(
-                async (readBuffer: Buffer, offset?: number, length?: number, position?: number) => {
-                    readBuffer.set(buffer, offset);
-                    return { bytesRead, buffer };
-                }
-            );
+            const shorterBuffer = buffer.subarray(0, buffer.length - 1);
+            const fakeStream: jasmine.SpyObj<any> = jasmine.createSpyObj('ReadableStream', ['getReader']);
+            const fakeReader: jasmine.SpyObj<any> = jasmine.createSpyObj('ReadableStreamDefaultReader', ['read', 'releaseLock']);
+            const blob: jasmine.SpyObj<Blob> = jasmine.createSpyObj('Blob', ['slice', 'stream']);
+            blob.slice.and.returnValue(blob);
+            blob.stream.and.returnValue(fakeStream);
+            fakeStream.getReader.and.returnValue(fakeReader);
+            fakeReader.read.and.resolveTo({ done: false, value: shorterBuffer });
 
-            const { success, error } = await verifyPeSignature(fileHandle as any, 0);
+            const { success, error } = await verifyPeSignature(blob, 0);
 
             expect(success).toBeFalse();
             expect(error?.message).toMatch(/wrong number of bytes read/);
         });
 
         it('should return error if invalid signature', async () => {
-            const buffer = Buffer.from(peSignature);
-            const bytesRead = buffer.length;
-            const fileHandle: jasmine.SpyObj<FileHandle> = jasmine.createSpyObj('FileHandle', ['read']);
-            fileHandle.read.and.callFake(
-                async (readBuffer: Buffer, offset?: number, length?: number, position?: number) => {
-                    readBuffer.set(buffer, offset);
-                    readBuffer[0] = 0;
-                    return { bytesRead, buffer };
-                }
-            );
+            const badBuffer = Buffer.from(peSignature);
+            const fakeStream: jasmine.SpyObj<any> = jasmine.createSpyObj('ReadableStream', ['getReader']);
+            const fakeReader: jasmine.SpyObj<any> = jasmine.createSpyObj('ReadableStreamDefaultReader', ['read', 'releaseLock']);
+            const blob: jasmine.SpyObj<Blob> = jasmine.createSpyObj('Blob', ['slice', 'stream']);
+            badBuffer[0] = 0;
+            blob.slice.and.returnValue(blob);
+            blob.stream.and.returnValue(fakeStream);
+            fakeStream.getReader.and.returnValue(fakeReader);
+            fakeReader.read.and.resolveTo({ done: false, value: badBuffer });
 
-            const { success, error } = await verifyPeSignature(fileHandle as any, 0);
+            const { success, error } = await verifyPeSignature(blob, 0);
 
             expect(success).toBeFalse();
             expect(error?.message).toMatch(/Invalid PE signatures differ at 0/);

--- a/src/create.ts
+++ b/src/create.ts
@@ -1,6 +1,7 @@
 import { PeFile } from './pe';
 import { PdbFile } from './pdb';
 import { extname } from 'node:path';
+import { openAsBlob } from 'node:fs';
 
 export async function createFromFile(path: string): Promise<PdbFile | PeFile> {
     if (!path) {
@@ -13,9 +14,11 @@ export async function createFromFile(path: string): Promise<PdbFile | PeFile> {
         throw new Error('File does not have .pdb, .exe, or .dll extension: ' + path);
     }
 
+    const fileBlob = await openAsBlob(path);
+
     if (extension === '.pdb') {
-        return PdbFile.createFromFile(path);
+        return PdbFile.createFromBlob(fileBlob);
     }
 
-    return PeFile.createFromFile(path);
+    return PeFile.createFromBlob(fileBlob);
 }

--- a/src/pdb.ts
+++ b/src/pdb.ts
@@ -1,8 +1,5 @@
-import { existsSync } from 'fs';
-import { FileHandle, open } from 'fs/promises';
-import { extname } from 'node:path';
 import { PdbGuid } from './guid';
-import { readUInt32, sizeOfInt16, sizeOfInt32, toUInt16, toUInt32 } from './int';
+import { readUInt32FromBlob, sizeOfInt16, sizeOfInt32, toUInt16, toUInt32 } from './int';
 import { PdbRootStream } from './root';
 import { verifyPdbSignature } from './signature';
 
@@ -21,68 +18,62 @@ export class PdbFile {
         return this.guid.age;
     }
 
-    static async createFromFile(pdbFilePath: string): Promise<PdbFile> {
-        if (!existsSync(pdbFilePath)) {
-            throw new Error(`PDB file does not exist at path: ${pdbFilePath}`);
+    static async createFromBlob(fileBlob: Blob): Promise<PdbFile> {
+        const { success, error } = await verifyPdbSignature(fileBlob);
+
+        if (!success) {
+            throw new Error('Could not verify pdb signature', error);
         }
 
-        const extension = extname(pdbFilePath).toLowerCase();
-        
-        if (extension !== '.pdb') {
-            throw new Error(`File does not have .pdb extension: ${pdbFilePath}`);
+        const root = await PdbRootStream.createFromBlob(fileBlob);
+
+        if (!root) {
+            throw new Error('Could not create RootStream');
         }
 
-        let fileHandle: FileHandle;
-        let pdbFile: PdbFile;
-        try {
-            fileHandle = await open(pdbFilePath, 'r');
+        const guidBytes = await PdbFile.getGuidBytesFromPdbStream(root, fileBlob);
+        const guidBytesLength = guidBytes.length;
+        const numberOfIntsToSkip = 3;
+        const guid_d1 = toUInt32(guidBytes, numberOfIntsToSkip * sizeOfInt32);
+        const guid_d2 = toUInt16(guidBytes, numberOfIntsToSkip * sizeOfInt32 + sizeOfD1Bytes);
+        const guid_d3 = toUInt16(guidBytes, numberOfIntsToSkip * sizeOfInt32 + sizeOfD1Bytes + sizeOfD2Bytes);
+        const guid_d4 = guidBytes.slice(guidBytesLength - sizeOfD4Bytes, guidBytesLength);
 
-            const { success, error } = await verifyPdbSignature(fileHandle);
-            
-            if (!success) {
-                throw new Error('Could not verify pdb signature', error);
-            }
-
-            const root = await PdbRootStream.createFromFile(pdbFilePath);
-
-            if (!root) {
-                throw new Error('Could not create RootStream');
-            }
-
-            const guidBytes = await PdbFile.getGuidBytesFromPdbStream(root, fileHandle);
-            const guidBytesLength = guidBytes.length;
-            const numberOfIntsToSkip = 3;
-            const guid_d1 = toUInt32(guidBytes, numberOfIntsToSkip * sizeOfInt32);
-            const guid_d2 = toUInt16(guidBytes, numberOfIntsToSkip * sizeOfInt32 + sizeOfD1Bytes);
-            const guid_d3 = toUInt16(guidBytes, numberOfIntsToSkip * sizeOfInt32 + sizeOfD1Bytes + sizeOfD2Bytes);
-            const guid_d4 = guidBytes.slice(guidBytesLength - sizeOfD4Bytes, guidBytesLength);
-
-            // Load age from the DBI information (PDB information age changes when using PDBSTR)
-            // vc140.pdb however, does not have this stream,
-            // so it does not have an age that can be used
-            // in the hash string
-            let age: number | undefined;
-            const dbiStreamPages = root.getStreamPages(3);
-            if (dbiStreamPages.length > 0) {
-                const ageOffset = dbiStreamPages[0] * root.blockSize + 2 * 4;
-                age = await readUInt32(fileHandle, ageOffset) || undefined;
-            } 
-            
-            const guid = new PdbGuid(guid_d1, guid_d2, guid_d3, guid_d4, age);
-            pdbFile = new PdbFile(guid);
-        } finally {
-            await fileHandle!?.close();
+        // Load age from the DBI information (PDB information age changes when using PDBSTR)
+        // vc140.pdb however, does not have this stream,
+        // so it does not have an age that can be used
+        // in the hash string
+        let age: number | undefined;
+        const dbiStreamPages = root.getStreamPages(3);
+        if (dbiStreamPages.length > 0) {
+            const ageOffset = dbiStreamPages[0] * root.blockSize + 2 * 4;
+            age = await readUInt32FromBlob(fileBlob, ageOffset) || undefined;
         }
 
-        return pdbFile;
+        const guid = new PdbGuid(guid_d1, guid_d2, guid_d3, guid_d4, age);
+        return new PdbFile(guid);
     }
 
-    private static async getGuidBytesFromPdbStream(root: PdbRootStream, fileHandle: FileHandle): Promise<Uint8Array> {
+    private static async getGuidBytesFromPdbStream(root: PdbRootStream, fileBlob: Blob): Promise<Uint8Array> {
         const pdbStreamPages = root.getStreamPages(1);
         const guidBytesLength = 4 * sizeOfInt32 + 2 * sizeOfInt16 + sizeOfD4Bytes;
-        const guidBytes = new Uint8Array(guidBytesLength);
+
+        // Calculate the file read offset based on the first page number from the stream
         const fileReadOffset = pdbStreamPages[0] * root.blockSize;
-        await fileHandle.read(guidBytes, 0, guidBytesLength, fileReadOffset);
+
+        // Create a Blob slice for the GUID bytes length starting from the calculated file read offset
+        const blobSlice = fileBlob.slice(fileReadOffset, fileReadOffset + guidBytesLength);
+
+        // Convert the Blob slice to an ArrayBuffer then to Uint8Array
+        const arrayBuffer = await blobSlice.arrayBuffer();
+        const guidBytes = new Uint8Array(arrayBuffer);
+
+        // Ensure the read bytes match the expected length
+        if (guidBytes.length !== guidBytesLength) {
+            throw new Error(`Expected to read ${guidBytesLength} bytes for GUID, but got ${guidBytes.length} bytes.`);
+        }
+
         return guidBytes;
     }
+
 }

--- a/src/pe.ts
+++ b/src/pe.ts
@@ -1,9 +1,6 @@
-import { existsSync } from "node:fs";
-import { open, FileHandle } from "node:fs/promises";
-import { peSignature, verifyPeSignature } from "./signature";
-import { readUInt32 } from "./int";
 import { PeGuid } from "./guid";
-import { extname } from "node:path";
+import { readUInt32FromBlob } from "./int";
+import { peSignature, verifyPeSignature } from "./signature";
 
 const machineSize = 2;
 const numberOfSectionSize = 2;
@@ -20,53 +17,33 @@ const optionalHeaderOffset = peSignature.length + machineSize + numberOfSectionS
 export class PeFile {
     constructor(public readonly guid: PeGuid) { }
 
-    static async createFromFile(peFilePath: string): Promise<PeFile> {
-        if (!existsSync(peFilePath)) {
-            throw new Error(`PE file does not exist at path: ${peFilePath}`);
+    static async createFromBlob(fileBlob: Blob): Promise<PeFile> {
+        const peSignaturePointer = 0x3C;
+        const peSignatureOffset = await readUInt32FromBlob(fileBlob, peSignaturePointer);
+
+        if (!peSignatureOffset && peSignatureOffset !== 0) {
+            throw new Error('Could not read PE signature offset');
         }
 
-        const extension = extname(peFilePath).toLowerCase();
+        const { success, error } = await verifyPeSignature(fileBlob, peSignatureOffset);
 
-        if (extension !== '.exe' && extension !== '.dll') {
-            throw new Error(`File does not have .exe or .dll extension: ${peFilePath}`);
+        if (!success) {
+            throw new Error('Could not verify PE signature', error);
         }
 
-        let fileHandle: FileHandle;
-        let peFile: PeFile;
-        try {
-            fileHandle = await open(peFilePath, 'r');
+        const timeStamp = await readUInt32FromBlob(fileBlob, peSignatureOffset + timeDateStampOffset);
 
-            const peSignaturePointer = 0x3C;
-            const peSignatureOffset = await readUInt32(fileHandle, peSignaturePointer);
-
-            if (!peSignatureOffset && peSignatureOffset !== 0) {
-                throw new Error('Could not read PE signature offset');
-            }
-
-            const { success, error } = await verifyPeSignature(fileHandle, peSignatureOffset);
-            
-            if (!success) {
-                throw new Error('Could not verify PE signature', error);
-            }
-
-            const timeStamp = await readUInt32(fileHandle, peSignatureOffset + timeDateStampOffset);
-            
-            if (!timeStamp && timeStamp !== 0) {
-                throw new Error('Could not read PE time stamp');
-            }
-
-            const sizeOfImage = await readUInt32(fileHandle, peSignatureOffset + optionalHeaderOffset + sizeOfImageOffset);
-            
-            if (!sizeOfImage && sizeOfImage !== 0) {
-                throw new Error('Could not read PE size of image');
-            }
-            
-            const guid = new PeGuid(timeStamp, sizeOfImage);
-            peFile = new PeFile(guid);
-        } finally {
-            await fileHandle!?.close();
+        if (!timeStamp && timeStamp !== 0) {
+            throw new Error('Could not read PE time stamp');
         }
 
-        return peFile;
+        const sizeOfImage = await readUInt32FromBlob(fileBlob, peSignatureOffset + optionalHeaderOffset + sizeOfImageOffset);
+
+        if (!sizeOfImage && sizeOfImage !== 0) {
+            throw new Error('Could not read PE size of image');
+        }
+
+        const guid = new PeGuid(timeStamp, sizeOfImage);
+        return new PeFile(guid);
     }
 }

--- a/src/root.ts
+++ b/src/root.ts
@@ -1,6 +1,5 @@
-import { FileHandle, open } from 'node:fs/promises';
+import { readUInt32ArrayFromBlob, readUInt32FromBlob, sizeOfInt32, toUInt32 } from './int';
 import { pdbSignature } from './signature';
-import { readUInt32, readUInt32Array, sizeOfInt32, toUInt32 } from './int';
 
 export class PdbRootStream {
 
@@ -17,14 +16,14 @@ export class PdbRootStream {
     public getStreamPages(streamIndex: number): number[] {
         // Skip the first stream which is the signature stream (?)
         let blocksOffset = 1 + this.streamsCount;
-    
+
         // Find the start of our read position
         for (let sidx = 0; sidx < streamIndex; sidx++) {
             const streamSize = this.getStreamSize(sidx);
             const streamPageBlockCount = getBlockCountForBytes(streamSize, this.blockSize);
             blocksOffset += streamPageBlockCount;
         }
-    
+
         // Read the current page starting at the read position
         const numberOfBlocksToRead = getBlockCountForBytes(this.getStreamSize(streamIndex), this.blockSize);
         const streamPages = this.readStreamDirectoryUInts(blocksOffset, numberOfBlocksToRead);
@@ -35,22 +34,22 @@ export class PdbRootStream {
         if (streamIndex >= this.streamsCount) {
             throw new Error(`stream index too large: ${streamIndex}, ${this.streamsCount}`);
         }
-    
+
         // Skip the signature stream at index 0 (?)
         return this.streamDirectory[1 + streamIndex];
     }
 
     private readStreamDirectoryUInts(offset: number, numberOfBlocksToRead: number): number[] {
         const uints = [] as number[];
-        
+
         for (let i = 0; i < numberOfBlocksToRead; i++) {
             uints[i] = this.streamDirectory[offset + i * sizeOfInt32];
         }
-    
+
         return uints;
     }
 
-    static async createFromFile(filePath: string): Promise<PdbRootStream> {
+    static async createFromBlob(fileBlob: Blob): Promise<PdbRootStream> {
         // LLVM.org refers to the first section of the file as The Superblock
         // At file offset 0 in an MSF file is the MSF SuperBlock, which is laid out as follows:
         //
@@ -63,50 +62,48 @@ export class PdbRootStream {
         //  ulittle32_t Unknown;
         //  ulittle32_t BlockMapAddr;
         // };
-        let fileHandle: FileHandle;
-        let pdbRootStream: PdbRootStream;
+        // Constants based on file structure
+        const sizeOfUInt32 = 4;
+        const directoryBytesLengthReadOffset = pdbSignature.length + 3 * sizeOfUInt32;
+        const blockMapReadOffset = pdbSignature.length + 5 * sizeOfUInt32;
+
         try {
-            fileHandle = await open(filePath, 'r');
-
+            // Read blockSize
             const blockSizeReadOffset = pdbSignature.length;
-            const blockSize = await readUInt32(fileHandle, blockSizeReadOffset);
-
+            const blockSize = await readUInt32FromBlob(fileBlob, blockSizeReadOffset);
             if (!blockSize) {
                 throw new Error('Could not read blockSize');
             }
 
+            // Read directoryBytesLength
             const directoryBytesLengthReadOffset = pdbSignature.length + 3 * sizeOfInt32;
-            const directoryBytesLength = await readUInt32(fileHandle, directoryBytesLengthReadOffset);
-
+            const directoryBytesLength = await readUInt32FromBlob(fileBlob, directoryBytesLengthReadOffset);
             if (!directoryBytesLength) {
                 throw new Error('Could not read directoryBytesLength');
             }
 
+            // Calculate blockMapAddress
             const blockMapAddressesCount = getBlockCountForBytes(directoryBytesLength, blockSize);
             const blockMapReadOffset = pdbSignature.length + 5 * sizeOfInt32;
-            const blockMapAddress = await readUInt32(fileHandle, blockMapReadOffset);       
-            
+
+            const blockMapAddress = await readUInt32FromBlob(fileBlob, blockMapReadOffset);
             if (!blockMapAddress) {
                 throw new Error('Could not read blockMapAddress');
             }
-            
-            const blockMapPages = await readUInt32Array(fileHandle, blockMapAddress * blockSize, blockMapAddressesCount);
-            
+            // Read block map pages
+            const blockMapPages = await readUInt32ArrayFromBlob(fileBlob, blockMapAddress * blockSize, blockMapAddressesCount);
+
             if (!blockMapPages) {
                 throw new Error('Could not read blockMapPages');
             }
 
-            const rootPageData = Buffer.alloc(blockMapAddressesCount * blockSize);
-            
+            // Read root page data
+            const rootPageData = new Uint8Array(blockMapAddressesCount * blockSize);
             for (let i = 0; i < blockMapAddressesCount; i++) {
                 const rootIndex = blockMapPages[i];
-                const bufferOffset = i * blockSize;
-                const fileReadOffset = rootIndex * blockSize;
-                const { bytesRead } = await fileHandle.read(rootPageData, bufferOffset, blockSize, fileReadOffset);
-                
-                if (bytesRead !== blockSize) {
-                    throw new Error(`Error reading root pages ${bytesRead} != ${blockSize} at index ${i}`);
-                }
+                const pageBlob = fileBlob.slice(rootIndex * blockSize, (rootIndex + 1) * blockSize);
+                const pageArrayBuffer = await pageBlob.arrayBuffer();
+                rootPageData.set(new Uint8Array(pageArrayBuffer), i * blockSize);
             }
 
             // Finally, read in the stream directory which is a block of uints with the following structure.
@@ -117,18 +114,18 @@ export class PdbRootStream {
             //      ulittle32_t StreamSizes[NumStreams];
             //      ulittle32_t StreamBlocks[NumStreams][];
             //    };
-            const streamDirectoryBufferLength = directoryBytesLength / sizeOfInt32;
-            const streamDirectory = [] as number[];
+            const streamDirectoryBufferLength = directoryBytesLength / sizeOfUInt32;
+            const streamDirectory = new Array(streamDirectoryBufferLength);
             for (let i = 0; i < streamDirectoryBufferLength; i++) {
-                streamDirectory[i] = toUInt32(rootPageData, i * sizeOfInt32);
+                streamDirectory[i] = toUInt32(rootPageData, i * sizeOfUInt32);
             }
 
-            pdbRootStream = new PdbRootStream(blockSize, directoryBytesLength, streamDirectory);
-        } finally {
-            await fileHandle!?.close();
+            // Construct the PdbRootStream
+            return new PdbRootStream(blockSize, directoryBytesLength, streamDirectory);
+        } catch (error) {
+            console.error('Failed to create PDB root stream:', error);
+            throw error;
         }
-
-        return pdbRootStream;
     }
 }
 

--- a/src/root.ts
+++ b/src/root.ts
@@ -68,21 +68,18 @@ export class PdbRootStream {
         const blockMapReadOffset = pdbSignature.length + 5 * sizeOfUInt32;
 
         try {
-            // Read blockSize
             const blockSizeReadOffset = pdbSignature.length;
             const blockSize = await readUInt32FromBlob(fileBlob, blockSizeReadOffset);
             if (!blockSize) {
                 throw new Error('Could not read blockSize');
             }
 
-            // Read directoryBytesLength
             const directoryBytesLengthReadOffset = pdbSignature.length + 3 * sizeOfInt32;
             const directoryBytesLength = await readUInt32FromBlob(fileBlob, directoryBytesLengthReadOffset);
             if (!directoryBytesLength) {
                 throw new Error('Could not read directoryBytesLength');
             }
 
-            // Calculate blockMapAddress
             const blockMapAddressesCount = getBlockCountForBytes(directoryBytesLength, blockSize);
             const blockMapReadOffset = pdbSignature.length + 5 * sizeOfInt32;
 
@@ -90,14 +87,12 @@ export class PdbRootStream {
             if (!blockMapAddress) {
                 throw new Error('Could not read blockMapAddress');
             }
-            // Read block map pages
             const blockMapPages = await readUInt32ArrayFromBlob(fileBlob, blockMapAddress * blockSize, blockMapAddressesCount);
 
             if (!blockMapPages) {
                 throw new Error('Could not read blockMapPages');
             }
 
-            // Read root page data
             const rootPageData = new Uint8Array(blockMapAddressesCount * blockSize);
             for (let i = 0; i < blockMapAddressesCount; i++) {
                 const rootIndex = blockMapPages[i];

--- a/src/root.ts
+++ b/src/root.ts
@@ -62,11 +62,6 @@ export class PdbRootStream {
         //  ulittle32_t Unknown;
         //  ulittle32_t BlockMapAddr;
         // };
-        // Constants based on file structure
-        const sizeOfUInt32 = 4;
-        const directoryBytesLengthReadOffset = pdbSignature.length + 3 * sizeOfUInt32;
-        const blockMapReadOffset = pdbSignature.length + 5 * sizeOfUInt32;
-
         try {
             const blockSizeReadOffset = pdbSignature.length;
             const blockSize = await readUInt32FromBlob(fileBlob, blockSizeReadOffset);
@@ -109,13 +104,12 @@ export class PdbRootStream {
             //      ulittle32_t StreamSizes[NumStreams];
             //      ulittle32_t StreamBlocks[NumStreams][];
             //    };
-            const streamDirectoryBufferLength = directoryBytesLength / sizeOfUInt32;
+            const streamDirectoryBufferLength = directoryBytesLength / sizeOfInt32;
             const streamDirectory = new Array(streamDirectoryBufferLength);
             for (let i = 0; i < streamDirectoryBufferLength; i++) {
-                streamDirectory[i] = toUInt32(rootPageData, i * sizeOfUInt32);
+                streamDirectory[i] = toUInt32(rootPageData, i * sizeOfInt32);
             }
 
-            // Construct the PdbRootStream
             return new PdbRootStream(blockSize, directoryBytesLength, streamDirectory);
         } catch (error) {
             console.error('Failed to create PDB root stream:', error);


### PR DESCRIPTION
BREAKING CHANGE: use Blobs instead of FileHandles because they can be backed by web compatible versions of the File API