### PR TITLE
feat: export PortablePdbFile and createFromFile

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
 export { PdbGuid, PeGuid } from './src/guid';
 export { PdbFile } from './src/pdb';
 export { PeFile } from './src/pe';
+export { PortablePdbFile } from './src/portable-pdb';
+export { createFromFile } from './src/create';


### PR DESCRIPTION
### Description

Allow symbol-upload to use createFromFile so it doesn't have to do it's own exe/dll/pdb format parsing.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
